### PR TITLE
Fix for javascript files.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -81,7 +81,6 @@ function activate(context) {
 		if (isJS) {
 			let opts = settings.js;
 			try {
-				opts.bracketize = true;
 				let results = minjs.minify(data, opts);
 				if(results.error) {
 					throw results.error;


### PR DESCRIPTION
The hardcoded `opts.bracketize = true;` prevents any javascript files from being minified.

This PR fixes that.

Removed harcoded bracketize = true.
- Allows for js files to be minified.