### PR TITLE
Remove line break in command description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "minify",
 	"displayName": "Minify",
-	"description": "Minify for VS Code.\nMinify with command, and (optionally) re-minify on save.",
+	"description": "Minify for VS Code. Minify with command, and (optionally) re-minify on save.",
 	"version": "0.4.3",
 	"publisher": "HookyQR",
 	"engines": {


### PR DESCRIPTION
Unneeded, and seems to create error as described in #51 (VS code writing as a comment in the settings file, which is then no longer commented).